### PR TITLE
Update TCD1304.py

### DIFF
--- a/TCD1304.py
+++ b/TCD1304.py
@@ -35,7 +35,7 @@ class TCD1304:
         self.ps = PowerSupply()
         
     def set_power_source():
-        self.ps.pv1 = 4
+        self.ps.pv1 = 5
 
     def start_icg_clock(self):
         self.pwmgen.set_state(sq3=True)


### PR DESCRIPTION
The input voltage for the TCD1304 on the carrier board should be +5V for the LDO version: "Connect +5 V to +5 V if you have a TCD1304-PCB with an LDO in place. "[1]

[1] https://tcd1304.wordpress.com/connecting-the-ccd-and-mcu/